### PR TITLE
add production environment to the heroku deployment

### DIFF
--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Took me a while to figure out why it worked on my offline version but not the GitHub version. This should fix the CI and deployments to Heroku should now work. You can find the info in the [docs](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment).