### PR TITLE
add frontend and backend labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,3 +3,6 @@ Backend:
 
 Frontend:
 - any: ['src/', '*.js', 'package*.json', 'tsconfig.json']
+
+documentation:
+- any: ['.env.example', 'README.md']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+Backend:
+- any: ['server/', '*py', '*(d|D)ocker*']
+
+Frontend:
+- any: ['src/', '*.js', '*.tsx', 'package*.json', 'tsconfig.json']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 Backend:
-- any: ['server/', '*py', '*(d|D)ocker*']
+- any: ['server/', '*.py', 'Dockerfile', '*docker*']
 
 Frontend:
-- any: ['src/', '*.js', '*.tsx', 'package*.json', 'tsconfig.json']
+- any: ['src/', '*.js', 'package*.json', 'tsconfig.json']

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,22 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@master
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Automatically add labels to pull request to know wether it's frontend, backend, or both _(although we should avoid those type of PRs)_