### PR TITLE
Fix production issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,4 @@ services:
     environment:
       - FLASK_ENV=production
       - APP_SETTINGS=config.ProductionConfig
+      - NODE_OPTIONS=--max-old-space-size=16384

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -8,5 +8,5 @@ from dotenv import load_dotenv
 load_dotenv()
 
 bind = f'0.0.0.0:{os.environ["PORT"]}'
-workers = multiprocessing.cpu_count() * 2 + 1
+workers = multiprocessing.cpu_count()
 threads = multiprocessing.cpu_count()

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,7 +1,9 @@
 var path = require('path');
 var webpack = require('webpack');
+var dotenv = require('dotenv');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 
+dotenv.config({ path: './.env' }); 
 
 module.exports = {
   mode: 'production',
@@ -41,5 +43,14 @@ module.exports = {
       inject: false,
       minify: 'auto'
     }),
+    new webpack.DefinePlugin({
+      'process.env.FIREBASE_API_KEY': JSON.stringify(process.env.FIREBASE_API_KEY),
+      'process.env.FIREBASE_AUTH_DOMAIN': JSON.stringify(process.env.FIREBASE_AUTH_DOMAIN),
+      'process.env.FIREBASE_PROJECT_ID': JSON.stringify(process.env.FIREBASE_PROJECT_ID),
+      'process.env.FIREBASE_STG_BUCKET': JSON.stringify(process.env.FIREBASE_STG_BUCKET),
+      'process.env.FIREBASE_MESSAGING_SDR_ID': JSON.stringify(process.env.FIREBASE_MESSAGING_SDR_ID),
+      'process.env.FIREBASE_APP_ID': JSON.stringify(process.env.FIREBASE_APP_ID),
+      'process.env.FIREBASE_MEASUREMENT_ID': JSON.stringify(process.env.FIREBASE_MEASUREMENT_ID),
+    })
   ]
 }


### PR DESCRIPTION
- Increase the max node memory to avoid javascript running out of heap when building the bundle.
- Reduce the number of workers for gunicorn so Heroku isn't forced to use swap space.
- Modify the production webpack to inject the firebase environment variables into the bundler since the process variable isn't available client-side.