### PR TITLE
Removed hardcoded urls and used environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ FLASK_ENV=development
 FLASK_APP=run:app
 APP_SETTINGS=server.config.DevelopmentConfig
 DATABASE_URL=sqlite:///app.db
+FLASK_HOST=http://localhost:5000
+PREACT_HOST=http://localhost:3000
 
 FIREBASE_API_KEY=
 FIREBASE_AUTH_DOMAIN=

--- a/server/run.py
+++ b/server/run.py
@@ -11,7 +11,7 @@ load_dotenv()
 
 
 dir = os.path.abspath(os.path.dirname(__file__))
-
+FRONT_END_HOST = os.getenv("PREACT_HOST")
 
 migrate = Migrate()
 
@@ -50,7 +50,7 @@ def create_app(config_filename=None):
     # add CORS 
     @app.after_request
     def after_request(response):
-        response.headers.add('Access-Control-Allow-Origin', 'http://localhost:3000')
+        response.headers.add('Access-Control-Allow-Origin', f'{FRONT_END_HOST}')
         response.headers.add('Access-Control-Allow-Headers', 'Content-Type,Authorization,Set-Cookie')
         response.headers.add('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE')
         response.headers.add('Access-Control-Allow-Credentials', 'true')

--- a/src/utils/firebase.tsx
+++ b/src/utils/firebase.tsx
@@ -7,10 +7,11 @@ import { firebaseConfig } from './firebaseConfig';
 initializeApp(firebaseConfig);
 const provider = new GithubAuthProvider();
 
-const auth = getAuth();
+const BACKEND_HOST = process.env.FLASK_HOST;
 
 // Referenced https://firebase.google.com/docs/auth/web/github-auth
 export const signInWithGithub = async () => {
+    const auth = getAuth();
     let token = null;
     try {
         const result = await signInWithPopup(auth, provider);
@@ -25,11 +26,11 @@ export const signInWithGithub = async () => {
 
     try {
         // send a request to Backend after signed up
-        let res = await fetch('http://localhost:5000/service/login', {
+        let res = await fetch(`${BACKEND_HOST}/service/login`, {
             headers: {
                 "Authorization": `Bearer ${token}`,
                 'Content-Type': 'application/json',
-                'Set-Cookie': 'SameSite=None; Secure;Domain=http://localhost:3000'
+                'Set-Cookie': `SameSite=None; Secure;Domain=${BACKEND_HOST}`
             },
             credentials: 'include',
             method: 'POST'

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -62,7 +62,8 @@ module.exports = {
       'FIREBASE_STG_BUCKET',
       'FIREBASE_MESSAGING_SDR_ID',
       'FIREBASE_APP_ID',
-      'FIREBASE_MEASUREMENT_ID'
+      'FIREBASE_MEASUREMENT_ID',
+      'FLASK_HOST'
     ])
   ]
 }

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -5,18 +5,20 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 dotenv.config({ path: './.env' }); 
 
+const frontendUrl = new URL(process.env.PREACT_HOST);
+
 module.exports = {
   mode: 'development',
   devtool: 'source-map',
   entry: ['./src/app.tsx'],
   devServer: {
-    port: 3000,
-    host: '0.0.0.0',
+    port: parseInt(frontendUrl.port),
+    host: frontendUrl.hostname,
     compress: false,
     historyApiFallback: true,
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',
+        target: process.env.FLASK_HOST,
         secure: false
       }
     }

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -43,14 +43,15 @@ module.exports = {
       inject: false,
       minify: 'auto'
     }),
-    new webpack.DefinePlugin({
-      'process.env.FIREBASE_API_KEY': JSON.stringify(process.env.FIREBASE_API_KEY),
-      'process.env.FIREBASE_AUTH_DOMAIN': JSON.stringify(process.env.FIREBASE_AUTH_DOMAIN),
-      'process.env.FIREBASE_PROJECT_ID': JSON.stringify(process.env.FIREBASE_PROJECT_ID),
-      'process.env.FIREBASE_STG_BUCKET': JSON.stringify(process.env.FIREBASE_STG_BUCKET),
-      'process.env.FIREBASE_MESSAGING_SDR_ID': JSON.stringify(process.env.FIREBASE_MESSAGING_SDR_ID),
-      'process.env.FIREBASE_APP_ID': JSON.stringify(process.env.FIREBASE_APP_ID),
-      'process.env.FIREBASE_MEASUREMENT_ID': JSON.stringify(process.env.FIREBASE_MEASUREMENT_ID),
-    })
+    new webpack.EnvironmentPlugin([
+      'FIREBASE_API_KEY',
+      'FIREBASE_AUTH_DOMAIN',
+      'FIREBASE_PROJECT_ID',
+      'FIREBASE_STG_BUCKET',
+      'FIREBASE_MESSAGING_SDR_ID',
+      'FIREBASE_APP_ID',
+      'FIREBASE_MEASUREMENT_ID',
+      'FLASK_HOST'
+    ])
   ]
 }


### PR DESCRIPTION
- Removed hardcoded url when the front-end makes calls to the backend, and vice-versa. 
- Updated .env.example to follow the new .env guidelines
- Removed hardcoded port and host from `webpack.dev.json`. Use the `PREACT_HOST` environment variable