### PR TITLE
create auth wrapper

### DIFF
--- a/server/exts.py
+++ b/server/exts.py
@@ -1,5 +1,7 @@
+from functools import wraps
+from flask import request
 from flask_sqlalchemy import SQLAlchemy
-from flask_login import LoginManager
+from flask_login import LoginManager, current_user
 import os
 
 
@@ -8,3 +10,25 @@ login_manager = LoginManager()
 
 LOCAL_AUTH_USER = os.getenv("LOCAL_AUTH_USER")
 LOCAL_AUTH_PASSWORD = os.getenv("LOCAL_AUTH_PASSWORD")
+
+
+def http_basic_authentication():
+    """
+    Basic HTTP authentication
+    """
+    if request.authorization and (
+        request.authorization.username == LOCAL_AUTH_USER
+        and request.authorization.password == LOCAL_AUTH_PASSWORD
+    ):
+        return True
+    return False
+
+
+def require_authentication(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not current_user.is_authenticated and not http_basic_authentication():
+            return login_manager.unauthorized()
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/server/routes/api.py
+++ b/server/routes/api.py
@@ -15,7 +15,13 @@ from telnetlib import STATUS
 from urllib import response
 from server.constants import res_msg
 from flask_login import login_user, login_required, logout_user, current_user
-from server.exts import db, LOCAL_AUTH_USER, LOCAL_AUTH_PASSWORD
+from server.exts import (
+    db,
+    LOCAL_AUTH_USER,
+    LOCAL_AUTH_PASSWORD,
+    http_basic_authentication,
+    require_authentication,
+)
 from server.models import Author, Inbox, Post, Comment, Requests, Like, Remote_Node
 from server.enums import ContentType
 from server.config import RUNTIME_SETTINGS
@@ -400,7 +406,7 @@ def get_inbox(author_id: str) -> Response:
 
 
 @bp.route("/authors/<string:author_id>/inbox", methods=["POST"])
-@login_required
+@require_authentication
 def post_inbox(author_id: str) -> Response:
     try:
         req_type = request.json["type"]
@@ -825,11 +831,7 @@ def set_settings() -> Response:
 
 @bp.route("/remotes", methods=["GET"])
 def get_remote() -> Response:
-    if (
-        not request.authorization
-        or request.authorization.username != LOCAL_AUTH_USER
-        or request.authorization.password != LOCAL_AUTH_PASSWORD
-    ):
+    if not http_basic_authentication():
         return utils.json_response(
             httpStatus.UNAUTHORIZED,
             {
@@ -851,11 +853,7 @@ def get_remote() -> Response:
 
 @bp.route("/remotes", methods=["PUT"])
 def add_remote() -> Response:
-    if (
-        not request.authorization
-        or request.authorization.username != LOCAL_AUTH_USER
-        or request.authorization.password != LOCAL_AUTH_PASSWORD
-    ):
+    if not http_basic_authentication():
         return utils.json_response(
             httpStatus.UNAUTHORIZED,
             {
@@ -888,11 +886,7 @@ def add_remote() -> Response:
 
 @bp.route("/remotes/<string:remote_id>", methods=["DELETE"])
 def delete_remote(remote_id: str) -> Response:
-    if (
-        not request.authorization
-        or request.authorization.username != LOCAL_AUTH_USER
-        or request.authorization.password != LOCAL_AUTH_PASSWORD
-    ):
+    if not http_basic_authentication():
         print(request.authorization.username, request.authorization.password)
         return utils.json_response(
             httpStatus.UNAUTHORIZED,

--- a/server/routes/api.py
+++ b/server/routes/api.py
@@ -176,7 +176,7 @@ def post(author_id: str) -> Response:
     "/authors/<string:author_id>/posts/<string:post_id>",
     methods=["POST", "PUT", "DELETE"],
 )
-@login_required
+@require_authentication
 def specific_post(author_id: str, post_id: str) -> Response:
     print(f"AUTHOR_ID {author_id}\nTYPE:{type(author_id)}")
     """Modify, create or delete a specific post."""
@@ -271,7 +271,7 @@ def get_comment(author_id: str, post_id: str, comment_id: str) -> Response:
 @bp.route(
     "/authors/<string:author_id>/posts/<string:post_id>/comments", methods=["POST"]
 )
-@login_required
+@require_authentication
 def post_comment(author_id: str, post_id: str) -> Response:
     try:
         title = request.json["title"]
@@ -336,7 +336,7 @@ def is_follower(author_id: str, follower_id: str) -> Response:
 @bp.route(
     "/authors/<string:author_id>/followers/<string:follower_id>", methods=["DELETE"]
 )
-@login_required
+@require_authentication
 def remove_follower(author_id: str, follower_id: str) -> Response:
     if current_user.id != follower_id:
         return (
@@ -360,7 +360,7 @@ def remove_follower(author_id: str, follower_id: str) -> Response:
 
 
 @bp.route("/authors/<string:author_id>/followers/<string:follower_id>", methods=["PUT"])
-@login_required
+@require_authentication
 def add_follower(author_id: str, follower_id: str) -> Response:
     if current_user.id != follower_id:
         return (
@@ -382,7 +382,7 @@ def add_follower(author_id: str, follower_id: str) -> Response:
 
 
 @bp.route("/authors/<string:author_id>/inbox", methods=["GET"])
-@login_required
+@require_authentication
 def get_inbox(author_id: str) -> Response:
     if current_user.id != author_id:
         return (
@@ -435,7 +435,7 @@ def post_inbox(author_id: str) -> Response:
 
 
 @bp.route("/authors/<string:author_id>/inbox", methods=["DELETE"])
-@login_required
+@require_authentication
 def clear_inbox(author_id: str) -> Response:
     if current_user.id != author_id:
         return (
@@ -667,7 +667,7 @@ def login_unit_test() -> Response:
 
 
 @bp.route("/logout", methods=["POST"])
-@login_required
+@require_authentication
 def logout() -> Response:
     try:
         logout_user()
@@ -679,13 +679,13 @@ def logout() -> Response:
 
 
 @bp.route("/login_test", methods=["GET"])
-@login_required
+@require_authentication
 def login_test() -> Response:
     return make_response(jsonify(message="Successful log in")), httpStatus.OK
 
 
 @bp.route("/user_me")
-@login_required
+@require_authentication
 def get_user_me() -> Response:
     try:
         return utils.json_response(
@@ -700,7 +700,7 @@ def get_user_me() -> Response:
 
 
 @bp.route("/admin/author/<string:author_id>", methods=["POST"])
-@login_required
+@require_authentication
 def modify_author(author_id: str) -> Response:
     if not current_user.isAdmin:
         return (
@@ -723,7 +723,7 @@ def modify_author(author_id: str) -> Response:
 
 
 @bp.route("/admin/author", methods=["PUT"])
-@login_required
+@require_authentication
 def create_author() -> Response:
     if not current_user.isAdmin:
         return (
@@ -763,7 +763,7 @@ def create_author() -> Response:
 
 
 @bp.route("/admin/author/<string:author_id>", methods=["DELETE"])
-@login_required
+@require_authentication
 def delete_author(author_id: str) -> Response:
     if not current_user.isAdmin:
         return (
@@ -785,7 +785,7 @@ def delete_author(author_id: str) -> Response:
 
 
 @bp.route("/admin/settings", methods=["GET"])
-@login_required
+@require_authentication
 def get_settings() -> Response:
     if not current_user.isAdmin:
         return (
@@ -805,7 +805,7 @@ def get_settings() -> Response:
 
 
 @bp.route("/admin/settings", methods=["POST"])
-@login_required
+@require_authentication
 def set_settings() -> Response:
     if not current_user.isAdmin:
         return (


### PR DESCRIPTION
Creates a wrapper for authentication. We might want to add it to any endpoint that the spec says remote in order to follow #40, #41, and #42. Let me know what you think.