### PR TITLE
Fetched all paginated friends posts

### DIFF
--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'preact/hooks';
 import { CircularProgress, Alert } from '@mui/material';
 import DrawerMenu from '../components/sidemenu-components/Drawer'
 
-import { getPosts } from '../utils/apiCalls';
+import { getPosts, get_author_id } from '../utils/apiCalls';
 
 import useAuthorId  from '../components/hooks/useAuthorId';  
 import useFollowers from '../components/hooks/useFollowers';
@@ -42,7 +42,6 @@ function Homepage(props : FeedProps) {
       }
 
       setFriendsPosts(friendsPostsList);
-      setLoading(false);
 
     }
 
@@ -50,9 +49,11 @@ function Homepage(props : FeedProps) {
       fetchFriendsPosts();
     } catch (err) {
       setErrMsg((err as Error).message);
+    } finally {
+      setLoading(false);
     }
 
-  }, [authorId, followers, friends])
+  }, [followers, friends])
 
   return (
     <div>


### PR DESCRIPTION
- Kept original implementation as refactoring it without the custom hooks brought up errors in other areas. 
- The homepage now loads all of the friends posts and displays them after all the calls are made.